### PR TITLE
 - Added the third option 'thumbnails' to the controlNav option

### DIFF
--- a/Configuration/FlexForm/Flexslider.xml
+++ b/Configuration/FlexForm/Flexslider.xml
@@ -464,6 +464,10 @@
 										<numIndex index="0">LLL:EXT:ws_flexslider/Resources/Private/Language/locallang.xml:ff.no</numIndex>
 										<numIndex index="1">false</numIndex>
 									</numIndex>
+									<numIndex index="4" type="array">
+										<numIndex index="0">LLL:EXT:ws_flexslider/Resources/Private/Language/locallang.xml:ff.thumbnails</numIndex>
+										<numIndex index="1">thumbnails</numIndex>
+									</numIndex>
 								</items>
 								<maxitems>1</maxitems>
 								<size>1</size>

--- a/Resources/Private/Language/locallang.xml
+++ b/Resources/Private/Language/locallang.xml
@@ -56,6 +56,7 @@
 			<!-- Primary Controls -->
 			<label index="ff.controlNav">Control navigation on</label>
 			<label index="ff.directionNav">Direction navigation on</label>
+			<label index="ff.thumbnails">Thumbnails</label>
 
 			<!-- Secondary Navigation -->
 			<label index="ff.secondarynavigation">Secondary navigation</label>
@@ -84,7 +85,7 @@
 			<label index="playText">Play</label>
 			<label index="prevText">Previous</label>
 			<label index="nextText">Next</label>
-			
+
 		</languageKey>
 		<languageKey index="de" type="array">
 

--- a/Resources/Private/Partials/Entry.html
+++ b/Resources/Private/Partials/Entry.html
@@ -4,10 +4,10 @@
 
     <f:section name="Entry">
 
-    <li>
+		<li data-thumb="{f:uri.image(src:item.image.uid, treatIdAsReference:1, width: settings.maxwidth, height: settings.maxheight)}" data-caption="{item.title}">
         <div class="slidercontent wsflexslider-{item.styleclass}">
             <f:if condition="{item.image}">
-                <f:image src="{item.image.uid}" treatIdAsReference="1" title="{item.image.originalResource.title}" alt="{item.image.originalResource.alternative}" width="{settings.maxwidth}" height="{settings.maxheight}" />
+            <f:image src="{item.image.uid}" treatIdAsReference="1" title="{item.image.originalResource.title}" alt="{item.image.originalResource.alternative}" width="{settings.maxwidth}" height="{settings.maxheight}" />
 
             </f:if>
             <div class="caption-wrapper caption-align-{item.textposition}">


### PR DESCRIPTION
 - Added 'data-thumb' and 'data-thumbcaption' attributes to the slides

This allows configurations like this example: http://flexslider.woothemes.com/thumbnail-controlnav.html
 to be used without having to edit the template.
( Previously only 'true' and 'false' could be selected )