### PR TITLE
[BUGFIX] Extension is now localizeable.

### DIFF
--- a/Classes/Controller/FlexsliderController.php
+++ b/Classes/Controller/FlexsliderController.php
@@ -13,31 +13,35 @@ namespace WapplerSystems\WsFlexslider\Controller;
  *
  * The TYPO3 project - inspiring people to share!
  */
+use WapplerSystems\WsFlexslider\Domain\Model\Content;
 
 /**
- *
- *
  * @package ws_flexslider
  * @license http://www.gnu.org/licenses/gpl.html GNU General Public License, version 3 or later
- *
  */
 class FlexsliderController extends \TYPO3\CMS\Extbase\Mvc\Controller\ActionController
 {
-
-
     /**
      * @var \WapplerSystems\WsFlexslider\Domain\Repository\ImageRepository
      * @inject
      */
     protected $imageRepository;
-
-
+    
+    /**
+     * @var \WapplerSystems\WsFlexslider\Domain\Repository\ContentRepository
+     * @inject
+     */
+    protected $contentRepository;
+    
+    /**
+     * initializes all Controller actions
+     *
+     * @return void
+     */
     public function initializeAction()
     {
-
         $this->configuration = $this->settings['flexslider'];
-
-
+        
         // Settings
 
         if (isset($this->settings['ff']['maxwidth']) && strlen($this->settings['ff']['maxwidth']) > 0) {
@@ -143,7 +147,6 @@ class FlexsliderController extends \TYPO3\CMS\Extbase\Mvc\Controller\ActionContr
         if (isset($this->settings['ff']['move']) && intval($this->settings['ff']['move']) > 0) {
             $this->settings['move'] = $this->settings['ff']['move'];
         }
-
     }
 
     /**
@@ -153,24 +156,34 @@ class FlexsliderController extends \TYPO3\CMS\Extbase\Mvc\Controller\ActionContr
      */
     public function listAction()
     {
-
-        $FeConfigManager = $this->objectManager->get('TYPO3\CMS\Extbase\Configuration\FrontendConfigurationManager');
-        $ts = $FeConfigManager->getTypoScriptSetup();
+        $feConfigManager = $this->objectManager->get('TYPO3\\CMS\\Extbase\\Configuration\\FrontendConfigurationManager');
+        $ts = $feConfigManager->getTypoScriptSetup();
 
         // Check Static include
         if (!isset($ts['plugin.']['tx_wsflexslider.']['view.']['templateRootPaths.'])) {
             $this->addFlashMessage('You have to include the static extension Template of the Flexslider.',
                 'Missing template', \TYPO3\CMS\Core\Messaging\AbstractMessage::ERROR);
         }
+        
+        $contentObject = $this->getTranslatedContentObject();
 
-        $contentObject = $this->configurationManager->getContentObject();
-        $contentElement = $contentObject->data;
-
-        $contentuid = $contentElement['uid'];
-
-        $this->view->assign('uid', $contentuid);
+        $this->view->assign('uid', $contentObject->getUid());
         $this->view->assign('settings', $this->settings);
-        $this->view->assign('images', $this->imageRepository->findByContentUid($contentuid));
+        $this->view->assign('images', $this->imageRepository->findByContentUid($contentObject->getUid()));
+    }
+    
+    /**
+     * Get tt_content record as translated object
+     *
+     * @return Content
+     */
+    protected function getTranslatedContentObject()
+    {
+        $contentObjectRecord = $this->configurationManager->getContentObject()->data;
+        
+        /** @var Content $contentObject */
+        $contentObject = $this->contentRepository->findByIdentifier($contentObjectRecord['uid']);
+        return $contentObject;
     }
 
 }

--- a/Classes/Domain/Model/Content.php
+++ b/Classes/Domain/Model/Content.php
@@ -1,0 +1,25 @@
+<?php
+namespace WapplerSystems\WsFlexslider\Domain\Model;
+
+/**
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+use TYPO3\CMS\Extbase\DomainObject\AbstractEntity;
+
+/**
+ * @package ws_flexslider
+ * @license http://www.gnu.org/licenses/gpl.html GNU General Public License, version 3 or later
+ */
+class Content extends AbstractEntity
+{
+    
+}

--- a/Classes/Domain/Repository/ContentRepository.php
+++ b/Classes/Domain/Repository/ContentRepository.php
@@ -1,0 +1,26 @@
+<?php
+namespace WapplerSystems\WsFlexslider\Domain\Repository;
+
+/**
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+use TYPO3\CMS\Extbase\Persistence\Repository;
+
+/**
+ * @author     Sven Wappler
+ * @subpackage Repository
+ * @license    http://www.gnu.org/licenses/gpl.html GNU General Public License, version 3 or later
+ */
+class ContentRepository extends Repository
+{
+    
+}

--- a/Configuration/TypoScript/setup.txt
+++ b/Configuration/TypoScript/setup.txt
@@ -20,7 +20,7 @@ page.includeCSS {
 plugin.tx_wsflexslider {
 
 	settings {
-	
+
 		maxwidth = {$plugin.tx_wsflexslider.maxwidth}
 		maxheight = {$plugin.tx_wsflexslider.maxheight}
 		animation = {$plugin.tx_wsflexslider.animation}
@@ -46,7 +46,7 @@ plugin.tx_wsflexslider {
 		multipleKeyboard = {$plugin.tx_wsflexslider.multipleKeyboard}
 		mousewheel = {$plugin.tx_wsflexslider.mousewheel}
 		pausePlay = {$plugin.tx_wsflexslider.pausePlay}
-		
+
 		controlsContainer = {$plugin.tx_wsflexslider.controlsContainer}
 		manualControls = {$plugin.tx_wsflexslider.manualControls}
 		sync = {$plugin.tx_wsflexslider.sync}
@@ -56,9 +56,9 @@ plugin.tx_wsflexslider {
 		minItems = {$plugin.tx_wsflexslider.minItems}
 		maxItems = {$plugin.tx_wsflexslider.maxItems}
 		move = {$plugin.tx_wsflexslider.move}
-		
+
 		carousel = {$plugin.tx_wsflexslider.carousel}
-		
+
 	}
 
 
@@ -80,10 +80,16 @@ plugin.tx_wsflexslider {
 	}
 	persistence {
 		storagePid = {$plugin.tx_wsflexslider.persistence.storagePid}
+		classes {
+			WapplerSystems\WsFlexslider\Domain\Model\Content {
+				mapping {
+					tableName = tt_content
+				}
+			}
+		}
 	}
 	features {
 		# uncomment the following line to enable the new Property Mapper.
 		# rewrittenPropertyMapper = 1
 	}
 }
-


### PR DESCRIPTION
This PR creates a little DomainModel for ContentObject. With this step Extbase automatically translates the contentObject into the right language. uid is still the same, but the hidden property _localizeUid is the uid of the translated tt_content-record, which helps fetching the translated images. There is still a core bug regarding strict mode, but that you can solve with my extension repair_translation.