### PR TITLE
Use updated language files

### DIFF
--- a/Configuration/TCA/tx_wsflexslider_domain_model_image.php
+++ b/Configuration/TCA/tx_wsflexslider_domain_model_image.php
@@ -35,10 +35,10 @@ return array(
     'types' => array(
         '1' => array(
             'showitem' => 'hidden;;1, title, sys_language_uid,
-				description;LLL:EXT:cms/locallang_ttc.xlf:bodytext_formlabel;;richtext:rte_transform[flag=rte_enabled|mode=ts_css], 
+				description;LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:bodytext_formlabel;;richtext:rte_transform[flag=rte_enabled|mode=ts_css], 
 				textposition, styleclass, link, fal_image,
 		
-				--div--;LLL:EXT:cms/locallang_ttc.xml:tabs.access,starttime, endtime'
+				--div--;LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:tabs.access,starttime, endtime'
         ),
     ),
     'palettes' => array(
@@ -47,22 +47,22 @@ return array(
     'columns' => array(
         'sys_language_uid' => array(
             'exclude' => 1,
-            'label' => 'LLL:EXT:lang/locallang_general.xml:LGL.language',
+            'label' => 'LLL:EXT:lang/locallang_general.xlf:LGL.language',
             'config' => array(
                 'type' => 'select',
                 'renderType' => 'selectSingle',
                 'foreign_table' => 'sys_language',
                 'foreign_table_where' => 'ORDER BY sys_language.title',
                 'items' => array(
-                    array('LLL:EXT:lang/locallang_general.xml:LGL.allLanguages', -1),
-                    array('LLL:EXT:lang/locallang_general.xml:LGL.default_value', 0)
+                    array('LLL:EXT:lang/locallang_general.xlf:LGL.allLanguages', -1),
+                    array('LLL:EXT:lang/locallang_general.xlf:LGL.default_value', 0)
                 ),
             ),
         ),
         'l10n_parent' => array(
             'displayCond' => 'FIELD:sys_language_uid:>:0',
             'exclude' => 1,
-            'label' => 'LLL:EXT:lang/locallang_general.xml:LGL.l18n_parent',
+            'label' => 'LLL:EXT:lang/locallang_general.xlf:LGL.l18n_parent',
             'config' => array(
                 'type' => 'select',
                 'items' => array(
@@ -78,7 +78,7 @@ return array(
             ),
         ),
         't3ver_label' => array(
-            'label' => 'LLL:EXT:lang/locallang_general.xml:LGL.versionLabel',
+            'label' => 'LLL:EXT:lang/locallang_general.xlf:LGL.versionLabel',
             'config' => array(
                 'type' => 'input',
                 'size' => 30,
@@ -87,7 +87,7 @@ return array(
         ),
         'hidden' => array(
             'exclude' => 1,
-            'label' => 'LLL:EXT:lang/locallang_general.xml:LGL.hidden',
+            'label' => 'LLL:EXT:lang/locallang_general.xlf:LGL.hidden',
             'config' => array(
                 'type' => 'check',
             ),
@@ -95,7 +95,7 @@ return array(
         'starttime' => array(
             'exclude' => 1,
             'l10n_mode' => 'mergeIfNotBlank',
-            'label' => 'LLL:EXT:lang/locallang_general.xml:LGL.starttime',
+            'label' => 'LLL:EXT:lang/locallang_general.xlf:LGL.starttime',
             'config' => array(
                 'type' => 'input',
                 'size' => 13,
@@ -111,7 +111,7 @@ return array(
         'endtime' => array(
             'exclude' => 1,
             'l10n_mode' => 'mergeIfNotBlank',
-            'label' => 'LLL:EXT:lang/locallang_general.xml:LGL.endtime',
+            'label' => 'LLL:EXT:lang/locallang_general.xlf:LGL.endtime',
             'config' => array(
                 'type' => 'input',
                 'size' => 13,


### PR DESCRIPTION
TYPO3 8 LTS doesn't find the ext:lang translations when using .xml, this is because the xlf files where moved to a subfolder and the core only remaps xlf. 

see: https://docs.typo3.org/typo3cms/extensions/core/Changelog/8.5/Deprecation-78647-MoveLanguageFilesFromEXTlanglocallang_ToResourcesPrivateLanguage.html

LLL:EXT:lang/locallang_general.xml would be LLL:EXT:lang/Resources/Private/Language/locallang_general.xlf, but this doesn't work in 7LTS. LLL:EXT:lang/locallang_general.xlf works in both but is deprecated now.

this is only tested in TYPO3 7 and 8 LTS not in 6LTS