### PR TITLE
changed requirement from "typo3/cms" to "typo3/cms-core"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
 		"source": "https://github.com/svewap/ws_flexslider"
 	},
 	"require": {
-		"typo3/cms": ">=8.7.0 <=9.5.99"
+		"typo3/cms-core": ">=8.7.0 <=9.5.99"
 	},
 	"replace": {
 		"ws_flexslider": "self.version",


### PR DESCRIPTION
Else the requirement leads to unsolvable situations like this one:

```
Installation request for typo3/cms-backend (locked at v9.4.0) -> satisfiable by typo3/cms[v9.4.0], typo3/cms-backend[v9.4.0].
```
Hope this lets me finally install ;-)