### PR TITLE
Make extension compatible with Typo3 v11

### DIFF
--- a/Classes/Controller/FlexsliderController.php
+++ b/Classes/Controller/FlexsliderController.php
@@ -29,13 +29,13 @@ class FlexsliderController extends ActionController
      * @var \WapplerSystems\WsFlexslider\Domain\Repository\ImageRepository
      * @TYPO3\CMS\Extbase\Annotation\Inject
      */
-    protected $imageRepository;
+    public $imageRepository;
     
     /**
      * @var \WapplerSystems\WsFlexslider\Domain\Repository\ContentRepository
      * @TYPO3\CMS\Extbase\Annotation\Inject
      */
-    protected $contentRepository;
+    public $contentRepository;
     
     /**
      * initializes all Controller actions

--- a/composer.json
+++ b/composer.json
@@ -20,11 +20,11 @@
 		"source": "https://github.com/svewap/ws_flexslider"
 	},
 	"require": {
-		"typo3/cms-core": "^9.5 || ^10.4"
+		"typo3/cms-core": "^9.5 || ^11.5"
 	},
 	"autoload": {
 		"psr-4": {
-			"WapplerSystems\\WsFlexslider\\": "Classes/"
+			"WapplerSystems\\WsFlexslider\\": "Classes"
 		}
 	},
 	"extra": {

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -30,7 +30,7 @@ $EM_CONF[$_EXTKEY] = [
     'version' => '1.5.16',
     'constraints' => [
         'depends' => [
-            'typo3' => '9.5.0-10.4.99',
+            'typo3' => '9.5.0-11.9.99',
         ],
         'conflicts' => [
         ],

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -11,7 +11,7 @@ call_user_func(
             'WapplerSystems.' . $extKey,
             'Pi1',
             [
-                'Flexslider' => 'list',
+                WapplerSystems\WsFlexslider\Controller\FlexsliderController::class => 'list',
             ],
             // non-cacheable actions
             []


### PR DESCRIPTION
Please pull this modifications to make the extension compatible with Typo3 version 11.x. 

- The backwards compatibility should not be affected (tested with v10).
- The extension version number is not touched.

Thx